### PR TITLE
Profile update/tick methods of the Collision Systems

### DIFF
--- a/src/libraries/aframe/main.js
+++ b/src/libraries/aframe/main.js
@@ -130,7 +130,7 @@ const collidable = [];
 const enemies = [];
 
 AFRAME.registerSystem("collision-system", {
-  tick() {
+  tick: function collisionSystemTick() {
     const entities = collidable;
     for (const entity of entities) {
       const ec = entity.components.collider;
@@ -139,6 +139,7 @@ AFRAME.registerSystem("collision-system", {
       entity.object3D.updateMatrixWorld();
       scene.updateBox(ec.offsetCollider, ec.collider, entity.object3D.matrixWorld);
     }
+    var t0 = performance.now();
     for (let i = 0; i < entities.length; i++) {
       const e1 = entities[i];
       const e1c = e1.components.collider;
@@ -154,6 +155,8 @@ AFRAME.registerSystem("collision-system", {
         e2.components.collider.collided = e1;
       }
     }
+    var t1 = performance.now();
+    console.log("collisionSystemTick " + (t1 - t0) + " milliseconds.");
   }
 });
 

--- a/src/libraries/aframe/scene.js
+++ b/src/libraries/aframe/scene.js
@@ -42,7 +42,7 @@ class Scene {
     AFRAME.registerComponent("rstats", {
       tick: () => {
         frame++;
-        if (perfMode && frame === 75) this.stop();
+        // if (perfMode && frame === 75) this.stop();
         stats("frame").tick();
         stats().update();
       }

--- a/src/libraries/tiny-ecs/main.js
+++ b/src/libraries/tiny-ecs/main.js
@@ -101,13 +101,14 @@ class CollisionSystem {
   constructor(entities) {
     this.query = entities.queryComponents([Mesh, Collider]);
   }
-  update() {
+  update = function collisionSystemUpdate() {
     for (const entity of this.query) {
       const ec = entity.collider;
       ec.collided = null;
       entity.mesh.mesh.updateMatrixWorld();
       scene.updateBox(ec.offsetCollider, ec.collider, entity.mesh.mesh.matrixWorld);
     }
+    var t0 = performance.now();
     for (let i = 0; i < this.query.length; i++) {
       const e1 = this.query[i];
       const e1c = e1.collider;
@@ -120,6 +121,8 @@ class CollisionSystem {
         e2c.collided = e1;
       }
     }
+    var t1 = performance.now();
+    console.log("collisionSystemUpdate " + (t1 - t0) + " milliseconds.");
   }
 }
 

--- a/src/three-scene.js
+++ b/src/three-scene.js
@@ -39,7 +39,7 @@ class Scene {
     this._renderer.setAnimationLoop(() => {
       if (!this._playing) return;
       frame++;
-      if (perfMode && frame === 75) this.stop();
+      // if (perfMode && frame === 75) this.stop();
       this.delta = perfMode ? 30 / 1000 : clock.getDelta();
       this.elapsed = clock.elapsedTime;
       update(this.delta, this.elapsed);


### PR DESCRIPTION
I've done some profiling. Most of the difference if not all comes from the THREE code in the tick / update methods of the collision system: 

- The tiny-ecs [update method](https://github.com/brianpeiris/TowerDefenseECS/blob/master/src/libraries/tiny-ecs/main.js#L104) takes ~50ms in both Firefox and Chrome. 
- The equivalent [tick method](https://github.com/brianpeiris/TowerDefenseECS/blob/master/src/libraries/aframe/main.js#L133) of the A-Frame version takes ~100ms in Chrome and ~200ms in Firefox. 

Most of the time seems to be spent in calls to `intersectsBox` that is particularly hot. The function is in the inner `for loop` and called about 2 million times per frame. A small difference will accumulate quickly. Next step would be figuring out the discrepancy in the collision calculation between the two versions.